### PR TITLE
Patch to properly support Python 3.8

### DIFF
--- a/bgrm/settings.py
+++ b/bgrm/settings.py
@@ -1,6 +1,7 @@
 # Author: Dylan Turner
 # Description: Keep app settings in one place
 
+from typing import Tuple
 from dataclasses import dataclass
 from argparse import ArgumentParser
 from subprocess import run, PIPE
@@ -13,7 +14,7 @@ class AppSettings:
     screen_height: int
     view_scale: float
     rm_thresh: float
-    fill_color: tuple[float, float, float]
+    fill_color: Tuple[float, float, float]
     bg_img: str
     blur: bool
     disable_win: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bgrm"
-version = "9"
+version = "10"
 description = "Remove backgrounds from video feeds in your web cam applications."
 authors = [ "Dylan Turner <dylantdmt@gmail.com>" ]
 license = "GPL-3.0-only"


### PR DESCRIPTION
I missed that a certain typing feature was only available in 3.9, so I adjusted to support 3.8.

Tested via pyenv, and it's working